### PR TITLE
Cache p.a.registry records used to populate vocabulary terms

### DIFF
--- a/collective/elephantvocabulary/caching.py
+++ b/collective/elephantvocabulary/caching.py
@@ -1,0 +1,81 @@
+from plone.memoize import ram
+from plone.registry.interfaces import IRecordModifiedEvent
+from zope.component import adapter
+from zope.component import getGlobalSiteManager
+from zope.component import getUtility
+from zope.component import provideHandler
+from zope.interface import implements
+from zope.interface import Interface
+
+
+def _record_from_registry_cachekey(method, self, key):
+    """Cache key for the VocabularyFactory.record_from_registry method.
+    `key` is the dotted name of the plone.app.registry record.
+    """
+    return key
+
+
+class ICachedRecordsRegistry(Interface):
+    """Registry for all p.a.registry records that have been RAM cached and
+    may need to have their cache invalidated when they change.
+    """
+
+    def get_record_keys():
+        """Returns keys of all cached p.a.registry records.
+        """
+
+    def register_registry_record(record_key):
+        """Adds a new p.a.registry record to the registry of cached records.
+        """
+
+
+class CachedRecordsRegistry(object):
+    """Global utility that keeps track of registry keys that are used by
+    collective.elephantvocabulary as either hidden_terms_from_registry or 
+    visible_terms_from_registry, and therefore need to cause a cache
+    invalidation if they are modified.
+    """
+    implements(ICachedRecordsRegistry)
+
+    def __init__(self):
+        self.record_keys = []
+
+    def get_record_keys(self):
+        return self.record_keys
+
+    def register_registry_record(self, record_key):
+        self.record_keys.append(record_key)
+
+
+# TODO: Move to ZCML
+voca_registry = CachedRecordsRegistry()
+gsm = getGlobalSiteManager()
+gsm.registerUtility(voca_registry, ICachedRecordsRegistry)
+
+
+def invalidate_records_cache():
+    """Invalidates the RAM cache used to cache
+    VocabularyFactory.record_from_registry.
+    """
+    # local import to avoid circular dependency
+    from collective.elephantvocabulary import vocabulary
+    cache = ram.choose_cache(vocabulary.VocabularyFactory.record_from_registry)
+    method_name = '.'.join([vocabulary.__name__, 'record_from_registry'])
+    cache.ramcache.invalidate(method_name)
+    # TODO: Only invalidate entries with a specific cache key
+
+
+@adapter(Interface, IRecordModifiedEvent)
+def record_modified_handler(record, event):
+    """Handler for IRecordModifiedEvent that fires cache invalidation for
+    cached registry records if necessary.
+    """
+    voca_registry = getUtility(ICachedRecordsRegistry)
+    for record_name in voca_registry.get_record_keys():
+        if record_name.startswith(event.record.interfaceName):
+            invalidate_records_cache()
+
+
+# TODO: Move to ZCML
+provideHandler(record_modified_handler)
+

--- a/collective/elephantvocabulary/test_caching.rst
+++ b/collective/elephantvocabulary/test_caching.rst
@@ -1,5 +1,5 @@
-Tests related to getting terms from registry
-============================================
+Test caching of registry records used to populate vocabularies
+==============================================================
 
 Some example content and vocabularies
 
@@ -16,6 +16,7 @@ Some example registry records
     >>> from plone.registry import field
     >>> from plone.registry import Record
     >>> from plone.registry.interfaces import IRegistry
+    >>> from collective.elephantvocabulary import wrap_vocabulary
 
     >>> example_registry_record = Record(
     ...         field.List(title=u"Test", min_length=0, max_length=10,
@@ -27,39 +28,30 @@ Some example registry records
     >>> registry.records['example.visible_terms'] = example_registry_record
 
 
-    >>> from collective.elephantvocabulary import wrap_vocabulary
+We create a vocabulary factory populated with hidden terms from a registry
+record:
 
     >>> wrapped_vocab_factory = wrap_vocabulary(example_vocab,
     ...         hidden_terms_from_registry='example.hidden_terms')
 
     >>> wrapped_vocab1 = wrapped_vocab_factory(context)
+    >>> [i.value for i in wrapped_vocab1]
+    [3, 4]
 
-Hidden terms should not grow after instanciating the vocab factory several
-times:
+If we now change the contents of the registry record to hide all values,
 
-    >>> wrapped_vocab_factory.hidden_terms
-    [1, 2]
+    >>> registry.records['example.hidden_terms'].value = [1, 2, 3, 4]
 
-    >>> wrapped_vocab2 = wrapped_vocab_factory(context)
+nothing seems to change in the vocabulary -  because access to registry records
+is cached:
 
-    >>> wrapped_vocab_factory.hidden_terms
-    [1, 2]
+    >>> [i.value for i in wrapped_vocab1]
+    [3, 4]
 
+Only once we invalidate the cache the new terms are reflected in the vocabulary:
 
-Same for visible terms - visible terms should not grow after instanciating the
-vocab factory several times:
-
-
-    >>> wrapped_vocab_factory = wrap_vocabulary(example_vocab,
-    ...         visible_terms_from_registry='example.visible_terms')
-
+    >>> from collective.elephantvocabulary.caching import invalidate_records_cache
+    >>> invalidate_records_cache()
     >>> wrapped_vocab1 = wrapped_vocab_factory(context)
-
-
-    >>> wrapped_vocab_factory.visible_terms
-    [1, 2]
-
-    >>> wrapped_vocab2 = wrapped_vocab_factory(context)
-
-    >>> wrapped_vocab_factory.visible_terms
-    [1, 2]
+    >>> [i.value for i in wrapped_vocab1]
+    []

--- a/collective/elephantvocabulary/test_terms_from_registry.rst
+++ b/collective/elephantvocabulary/test_terms_from_registry.rst
@@ -1,0 +1,47 @@
+Tests related to getting terms from registry
+============================================
+
+Some example content and vocabularies
+
+    >>> context = layer.context
+    >>> example_vocab = layer.example_vocab
+    >>> example_source = layer.example_source
+    >>> [i.value for i in example_vocab]
+    [1, 2, 3, 4]
+
+    >>> from collective.elephantvocabulary import wrap_vocabulary
+
+    >>> wrapped_vocab_factory = wrap_vocabulary(example_vocab,
+    ...         hidden_terms_from_registry='example.hidden_terms')
+
+    >>> wrapped_vocab1 = wrapped_vocab_factory(context)
+
+Hidden terms should not grow after instanciating the vocab factory several
+times:
+
+    >>> wrapped_vocab_factory.hidden_terms
+    [1, 2]
+
+    >>> wrapped_vocab2 = wrapped_vocab_factory(context)
+
+    >>> wrapped_vocab_factory.hidden_terms
+    [1, 2]
+
+
+Same for visible terms - visible terms should not grow after instanciating the
+vocab factory several times:
+
+
+    >>> wrapped_vocab_factory = wrap_vocabulary(example_vocab,
+    ...         visible_terms_from_registry='example.visible_terms')
+
+    >>> wrapped_vocab1 = wrapped_vocab_factory(context)
+
+
+    >>> wrapped_vocab_factory.visible_terms
+    [1, 2, 3]
+
+    >>> wrapped_vocab2 = wrapped_vocab_factory(context)
+
+    >>> wrapped_vocab_factory.visible_terms
+    [1, 2, 3]

--- a/collective/elephantvocabulary/testing.py
+++ b/collective/elephantvocabulary/testing.py
@@ -11,7 +11,12 @@ from plone.registry import Registry
 from plone.registry.interfaces import IRegistry
 
 from plone.testing import Layer
-from plone.testing.zca import LAYER_CLEANUP
+from plone.testing.zca import ZCML_DIRECTIVES
+
+from collective.elephantvocabulary.caching import ICachedRecordsRegistry
+from collective.elephantvocabulary.caching import CachedRecordsRegistry
+
+from zope.configuration.xmlconfig import XMLConfig
 
 
 class ExampleSource(SimpleVocabulary):
@@ -30,9 +35,12 @@ class ExampleVocabFactory(SimpleVocabulary):
 
 
 class VocabularyLayer(Layer):
-    defaultBases = (LAYER_CLEANUP,)
+    defaultBases = (ZCML_DIRECTIVES,)
 
     def setUp(self):
+        import plone.memoize
+        XMLConfig('configure.zcml', plone.memoize)()
+
         self.context = None
         self.example_vocab = SimpleVocabulary.fromValues([1, 2, 3, 4])
         self.example_source = ExampleSource(
@@ -44,6 +52,9 @@ class VocabularyLayer(Layer):
 
         plone_registry = Registry()
         provideUtility(plone_registry, IRegistry)
+
+        voca_registry = CachedRecordsRegistry()
+        provideUtility(voca_registry, ICachedRecordsRegistry)
 
 
 VOCAB_LAYER = VocabularyLayer()

--- a/collective/elephantvocabulary/tests.py
+++ b/collective/elephantvocabulary/tests.py
@@ -13,5 +13,10 @@ def test_suite():
                     package='collective.elephantvocabulary',
                     optionflags=doctest.ELLIPSIS),
                 layer = VOCAB_LAYER),
+        layered(doctest.DocFileSuite(
+                    'test_terms_from_registry.rst',
+                    package='collective.elephantvocabulary',
+                    optionflags=doctest.ELLIPSIS),
+                layer = VOCAB_LAYER),
     ])
     return suite

--- a/collective/elephantvocabulary/tests.py
+++ b/collective/elephantvocabulary/tests.py
@@ -18,5 +18,10 @@ def test_suite():
                     package='collective.elephantvocabulary',
                     optionflags=doctest.ELLIPSIS),
                 layer = VOCAB_LAYER),
+        layered(doctest.DocFileSuite(
+                    'test_caching.rst',
+                    package='collective.elephantvocabulary',
+                    optionflags=doctest.ELLIPSIS),
+                layer = VOCAB_LAYER),
     ])
     return suite

--- a/collective/elephantvocabulary/tests.rst
+++ b/collective/elephantvocabulary/tests.rst
@@ -187,10 +187,10 @@ Or we can use them in combination.
     ...         field.List(title=u"Test", min_length=0, max_length=10, 
     ...                    value_type=field.Int(title=u"Value")))
     >>> example_registry_record2.value = [1, 2, 3]
-    >>> registry.records['example.visible_terms'] = example_registry_record2
+    >>> registry.records['example2.visible_terms'] = example_registry_record2
 
     >>> wrapped_vocab = wrap_vocabulary(example_vocab,
-    ...         visible_terms_from_registry='example.visible_terms',
+    ...         visible_terms_from_registry='example2.visible_terms',
     ...         hidden_terms_from_registry='example.hidden_terms')(context)
     >>> [i.value for i in wrapped_vocab]
     [3]

--- a/collective/elephantvocabulary/vocabulary.py
+++ b/collective/elephantvocabulary/vocabulary.py
@@ -53,7 +53,9 @@ class VocabularyFactory(object):
                                              None)
             if record and type(record) == list:
                 if type(self.visible_terms) == list:
-                    self.visible_terms.append(record)
+                    for term in record:
+                        if not term in self.visible_terms:
+                            self.visible_terms.append(term)
                 else:
                     self.visible_terms = record
 
@@ -73,7 +75,9 @@ class VocabularyFactory(object):
                                              None)
             if record and type(record) == list:
                 if type(self.hidden_terms) == list:
-                    self.hidden_terms.append(record)
+                    for term in record:
+                        if not term in self.hidden_terms:
+                            self.hidden_terms.append(term)
                 else:
                     self.hidden_terms = record
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(name='collective.elephantvocabulary',
           'zope.interface',
           'zope.component',
           'zope.schema',
+          'plone.memoize',
       ],
       extras_require = {
           'tests': [


### PR DESCRIPTION
Currently, when terms get populated from registry records, those records get fetched on every `__call__` of the vocabulary factory.

It might be desirable to cache those records (and invalidate those caches whenever the p.a.registry record is modified).