### PR TITLE
Reference to persistent registry utility causes object access across different ZODB connections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ History
 0.2.3 (unreleased)
 ------------------
 
+ * Don't memoize the persistent plone.registry utility. This avoids issues
+   with object access across different ZODB connections (see issue #2).
+   [lgraf]
+
  * Split the ``README.rst`` up into several files. Put the testing
    part in ``tests.rst`` in the main directory so this test file can also
    be found when we are distributed on PyPI. [maurits]

--- a/collective/elephantvocabulary/vocabulary.py
+++ b/collective/elephantvocabulary/vocabulary.py
@@ -29,13 +29,10 @@ class VocabularyFactory(object):
         self.hidden_terms = hidden_terms
         self.hidden_terms_from_registry = hidden_terms_from_registry
         self.wrapper_class = wrapper_class
-        self._plone_registry = None
 
     @property
     def plone_registry(self):
-        if PLONE_REGISTRY is True and not self._plone_registry:
-            self._plone_registry = getUtility(IRegistry)
-        return self._plone_registry
+        return getUtility(IRegistry)
 
     def __call__(self, context):
 


### PR DESCRIPTION
In the `plone_registry` property in [`vocabulary.py:35`](https://github.com/collective/collective.elephantvocabulary/blob/3a17957d841d2b8aba21431c33c1a9393b39c00b/collective/elephantvocabulary/vocabulary.py#L35) a reference to the persistent utility of `plone.app.registry` is being held.

This causes a problem, because the vocabulary factory will be instanciated with different contexts, which have their own ZODB connections. So in certain circumstances this will lead to the vocabulary factory's context having a ZODB connection `B`, whereas the registry utility still has a different connection `B`. This then causes a `ConnectionStateError` when trying to access the registry (at [`vocabulary.py:53`](https://github.com/collective/collective.elephantvocabulary/blob/3a17957d841d2b8aba21431c33c1a9393b39c00b/collective/elephantvocabulary/vocabulary.py#L53) for example):

```
  Module ZPublisher.Publish, line 126, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 46, in call_object
  Module plone.z3cform.layout, line 70, in __call__
  Module plone.z3cform.layout, line 54, in update
  Module plone.dexterity.browser.add, line 112, in update
  Module plone.z3cform.fieldsets.extensible, line 59, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 134, in update
  Module z3c.form.group, line 47, in update
  Module z3c.form.group, line 43, in updateWidgets
  Module z3c.form.field, line 275, in update
  Module z3c.form.browser.select, line 50, in update
  Module z3c.form.browser.widget, line 70, in update
  Module z3c.form.widget, line 199, in update
  Module z3c.form.widget, line 193, in updateTerms
  Module zope.component._api, line 107, in getMultiAdapter
  Module zope.component._api, line 120, in queryMultiAdapter
  Module zope.component.registry, line 238, in queryMultiAdapter
  Module zope.interface.adapter, line 532, in queryMultiAdapter
  Module z3c.form.term, line 96, in ChoiceTerms
  Module zope.schema._field, line 349, in bind
  Module collective.elephantvocabulary.vocabulary, line 53, in __call__
  Module plone.registry.registry, line 43, in get
  Module ZODB.Connection, line 857, in setstate
ConnectionStateError: Shouldn't load state for 0x0dce when the connection is closed
```

Proposed solution: Don't memoize the `plone.app.registry` utility, but instead query for it every time we need to access the registry.
